### PR TITLE
Fixed link to trigger documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ async function patchDocument(ctx: MutationCtx, documentId: Id<"documents">, patc
 }
 ```
 
-Or attach a [trigger](https://docs.convex.dev/triggers) to automatically write to the history table when a mutation changes a document:
+Or attach a [trigger](https://www.npmjs.com/package/convex-helpers#triggers) to automatically write to the history table when a mutation changes a document:
 
 ```ts
 const triggers = new Triggers<DataModel>();


### PR DESCRIPTION
The "trigger" link under the Usage section of the readme file pointed to a nonexistent page in the Convex docs. I updated it to point to the relevant part of the convex-helper package docs.