### PR TITLE
Fix vacuumHistoryRecursive infinite loop bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "convex-table-history",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "convex-table-history",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "convex-helpers": "^0.1.100"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "support@convex.dev",
     "url": "https://github.com/ldanilek/table-history/issues"
   },
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "Apache-2.0",
   "keywords": [
     "convex",

--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -140,7 +140,19 @@ describe("table-history", () => {
     await t.mutation(api.lib.update, { id: "2", doc: null, serializability, attribution: "test" });
     const minTsToKeep = await t.mutation(api.lib.update, { id: "3", doc: { name: "shoes", count: 2 }, serializability, attribution: "test" });
     await t.mutation(api.lib.vacuumHistory, { minTsToKeep });
-    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    let callbacks = 0;
+    const maxCallbacks = 5;
+    await t.finishAllScheduledFunctions(() => {
+      callbacks++;
+      if (callbacks > maxCallbacks) {
+        throw new Error(`Too many callbacks - possible infinite loop`);
+      }
+      vi.runAllTimers();
+    });
+
+    const iterations = callbacks - 1; // subtract final "queue empty" check
+    expect(iterations).toEqual(1);
 
     const history = await t.query(api.lib.listHistory, {
       maxTs: minTsToKeep,
@@ -149,6 +161,124 @@ describe("table-history", () => {
     expect(history.page.length).toEqual(2);
     expect(history.page[0].doc).toEqual({ name: "shoes", count: 2 });
     expect(history.page[1].doc).toEqual({ name: "beans", count: 5 });
+
+    vi.useRealTimers();
+  });
+
+  test("vacuum empty table", async () => {
+    vi.useFakeTimers();
+
+    const t = convexTest(schema, modules);
+
+    // Vacuum on empty table should terminate immediately
+    const minTsToKeep = Date.now();
+    await t.mutation(api.lib.vacuumHistory, { minTsToKeep });
+
+    let callbacks = 0;
+    const maxCallbacks = 5;
+    await t.finishAllScheduledFunctions(() => {
+      callbacks++;
+      if (callbacks > maxCallbacks) {
+        throw new Error(`Too many callbacks - possible infinite loop`);
+      }
+      vi.runAllTimers();
+    });
+
+    const iterations = callbacks - 1; // subtract final "queue empty" check
+    expect(iterations).toEqual(1);
+
+    vi.useRealTimers();
+  });
+
+  test("vacuum with gap", async () => {
+    vi.useFakeTimers();
+
+    const t = convexTest(schema, modules);
+    const serializability: Serializability = "table";
+
+    // Create entries, then vacuum with a minTsToKeep beyond the last entry
+    // This is the common case: calling vacuum({ minTsToKeep: Date.now() }) when entries are older
+    await t.mutation(api.lib.update, { id: "1", doc: { name: "beans", count: 10 }, serializability, attribution: "test" });
+    const lastEntryTs = await t.mutation(api.lib.update, { id: "2", doc: { name: "socks", count: 1 }, serializability, attribution: "test" });
+
+    // Vacuum with minTsToKeep > lastEntryTs creates a gap
+    const minTsToKeep = lastEntryTs + 10000;
+    await t.mutation(api.lib.vacuumHistory, { minTsToKeep });
+
+    let callbacks = 0;
+    const maxCallbacks = 5;
+    await t.finishAllScheduledFunctions(() => {
+      callbacks++;
+      if (callbacks > maxCallbacks) {
+        throw new Error(`Too many callbacks - possible infinite loop`);
+      }
+      vi.runAllTimers();
+    });
+
+    const iterations = callbacks - 1; // subtract final "queue empty" check
+    expect(iterations).toEqual(1);
+
+    vi.useRealTimers();
+  });
+
+  test("vacuum with pagination", async () => {
+    vi.useFakeTimers();
+
+    const t = convexTest(schema, modules);
+    const serializability: Serializability = "table";
+    const pageSize = 100; // matches vacuumHistory's numItems
+    const numEntries = 250;
+
+    let minTsToKeep = 0;
+    for (let i = 0; i < numEntries; i++) {
+      minTsToKeep = await t.mutation(api.lib.update, { id: `doc-${i}`, doc: { value: i }, serializability, attribution: "test" });
+    }
+
+    await t.mutation(api.lib.vacuumHistory, { minTsToKeep });
+
+    let callbacks = 0;
+    const maxCallbacks = 10;
+    await t.finishAllScheduledFunctions(() => {
+      callbacks++;
+      if (callbacks > maxCallbacks) {
+        throw new Error(`Too many callbacks - possible infinite loop`);
+      }
+      vi.runAllTimers();
+    });
+
+    const iterations = callbacks - 1; // subtract final "queue empty" check
+    const expectedIterations = Math.ceil(numEntries / pageSize);
+    expect(iterations).toEqual(expectedIterations);
+
+    vi.useRealTimers();
+  });
+
+  test("vacuum with no entries in range", async () => {
+    vi.useFakeTimers();
+
+    const t = convexTest(schema, modules);
+    const serializability: Serializability = "table";
+
+    // Create entries with timestamps, then vacuum with minTsToKeep before all entries
+    const firstEntryTs = await t.mutation(api.lib.update, { id: "1", doc: { name: "beans", count: 10 }, serializability, attribution: "test" });
+    await t.mutation(api.lib.update, { id: "2", doc: { name: "socks", count: 1 }, serializability, attribution: "test" });
+
+    // Vacuum with minTsToKeep before any entries exist
+    const minTsToKeep = firstEntryTs - 1;
+    await t.mutation(api.lib.vacuumHistory, { minTsToKeep });
+
+    let callbacks = 0;
+    const maxCallbacks = 5;
+    await t.finishAllScheduledFunctions(() => {
+      callbacks++;
+      if (callbacks > maxCallbacks) {
+        throw new Error(`Too many callbacks - possible infinite loop`);
+      }
+      vi.runAllTimers();
+    });
+
+    const iterations = callbacks - 1; // subtract final "queue empty" check
+    expect(iterations).toEqual(1);
 
     vi.useRealTimers();
   });

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -323,12 +323,14 @@ export const vacuumHistoryRecursive = internalMutation({
         minTsToKeep: maxTs,
       });
     }
-    await ctx.scheduler.runAfter(0, internal.lib.vacuumHistoryRecursive, {
-      minTsToKeep: args.minTsToKeep,
-      paginationOpts: {
-        numItems: args.paginationOpts.numItems,
-        cursor: toDelete.continueCursor,
-      }
-    });
+    if (!toDelete.isDone) {
+      await ctx.scheduler.runAfter(0, internal.lib.vacuumHistoryRecursive, {
+        minTsToKeep: args.minTsToKeep,
+        paginationOpts: {
+          numItems: args.paginationOpts.numItems,
+          cursor: toDelete.continueCursor,
+        }
+      });
+    }
   },
 });

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -323,14 +323,15 @@ export const vacuumHistoryRecursive = internalMutation({
         minTsToKeep: maxTs,
       });
     }
-    if (!toDelete.isDone) {
-      await ctx.scheduler.runAfter(0, internal.lib.vacuumHistoryRecursive, {
-        minTsToKeep: args.minTsToKeep,
-        paginationOpts: {
-          numItems: args.paginationOpts.numItems,
-          cursor: toDelete.continueCursor,
-        }
-      });
+    if (toDelete.isDone) {
+      return;
     }
+    await ctx.scheduler.runAfter(0, internal.lib.vacuumHistoryRecursive, {
+      minTsToKeep: args.minTsToKeep,
+      paginationOpts: {
+        numItems: args.paginationOpts.numItems,
+        cursor: toDelete.continueCursor,
+      }
+    });
   },
 });


### PR DESCRIPTION
### Bug

In the current code, `vacuumHistoryRecursive` always schedules itself at the end, even when pagination indicated there was nothing more to process (`isDone=true`).

This caused infinite loops in these scenarios:

  - Empty table - no entries to vacuum, but keeps scheduling itself indefinitely
  - Gap between last entry and minTsToKeep - e.g., entries at ts=100,200 but minTsToKeep=500
  - No entries in vacuum range - entries exist but all have timestamps after minTsToKeep

  ### Fix

  Only schedule a next iteration when `!toDelete.isDone`:

```
  if (toDelete.isDone) {
    return;
  }
  await ctx.scheduler.runAfter(0, internal.lib.vacuumHistoryRecursive, { ... });
```

###  Tests

Added tests for all three infinite loop scenarios plus a pagination test to verify multi-page vacuum still works correctly.

### Contribution

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.